### PR TITLE
chore: add health check using Bitcoin RPC getblockcount

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ async fn start_main_server(config: Config) -> Result<()> {
     )?;
 
     let routes = vec![
+        RouteInfo::new("/health", "Useful for health check", get(get_tip_height)),
         RouteInfo::new(
             "/api/blocks/tip/height",
             "Get the current blockchain tip height.",


### PR DESCRIPTION
It adds a health check that calls the bitcoind RPC getblockcount endpoint to verify that the service is appropriately connected to its main dependency. Although this is heavier than a simple 200-response check, it ensures that the service and its critical dependency function correctly —at least somehow.